### PR TITLE
修复preview-help插件使用本地json或导入json时，配置项中填写的background_URL无效

### DIFF
--- a/plugins/preview-help/src/index.ts
+++ b/plugins/preview-help/src/index.ts
@@ -572,6 +572,12 @@ export function apply(ctx, config) {
 
 
                     if (config.helpmode === '3' || config.helpmode === '3.2') { // 模式 3.2 同样使用 JSON 导入
+                        if (localBackgroundURL) {
+                            let parsedJson = JSON.parse(helpContent); // 解析 JSON
+                            parsedJson.config.backgroundImage = localBackgroundURL; // 改写背景图字段
+                            helpContent = JSON.stringify(parsedJson); // 转回字符串
+                        }  
+                      
                         // JSON模式处理
                         const textarea = await logElementAction('.popup-content textarea', '输入JSON内容');
                         await page.evaluate((element, content) => {


### PR DESCRIPTION
避免配置项中填写的背景图片被json覆盖，确保随机背景图正确填写